### PR TITLE
"Sign In With Apple" didn't return the name

### DIFF
--- a/src/Providers/SignInWithAppleProvider.php
+++ b/src/Providers/SignInWithAppleProvider.php
@@ -103,15 +103,17 @@ class SignInWithAppleProvider extends AbstractProvider implements ProviderInterf
 
     protected function mapUserToObject(array $user)
     {
-        if (request()->filled("user")
-            && array_key_exists("name", $user)
-        ) {
-            $user["name"] = json_decode(request("user"), true)["name"];
-            $fullName = trim(
-                ($user["name"]['firstName'] ?? "")
-                . " "
-                . ($user["name"]['lastName'] ?? "")
-            );
+        if (request()->filled("user")) {
+            $userRequest = json_decode(request("user"), true);
+
+            if (array_key_exists("name", $userRequest)) {
+                $user["name"] = $userRequest["name"];
+                $fullName = trim(
+                    ($user["name"]['firstName'] ?? "")
+                    . " "
+                    . ($user["name"]['lastName'] ?? "")
+                );
+            }
         }
 
         return (new User)


### PR DESCRIPTION
This pull request fixed #2. Apple sends the name in the `request('user')`. Here is an examle what Apple sends:

```
{"email":"XXXXXXXX@privaterelay.appleid.com","name":{"firstName":"poldixd","lastName":"poldixd"}}
```

This was always `false`:

https://github.com/GeneaLabs/laravel-sign-in-with-apple/blob/867204f966c5052fab09df4a469b3dc8348ef368/src/Providers/SigninWithAppleProvider.php#L106-L107