### PR TITLE
Increase the number of illumiante/support package versions allowed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "genealabs/laravel-socialiter": "Automatic user resolution and persistence for any Laravel Socialite driver."
     },
     "require": {
-        "illuminate/support": "^7.0",
+        "illuminate/support": "~5.7 || ^6.0 || ^7.0",
         "laravel/socialite": "^4.3"
     },
     "require-dev": {


### PR DESCRIPTION
We have Laravel 6.2 installed, but we could not add laravel-sign-in-with-apple to our project because of the tight dependency on illuminate-support.  