### PR TITLE
feat(deps): Add Laravel 8.x support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,4 +43,4 @@ jobs:
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Run tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit --testsuite Feature,Unit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3', '8.4']
+        laravel: ['8.*', '9.*', '10.*', '11.*', '12.*']
+        exclude:
+          - php: '8.1'
+            laravel: '11.*'
+          - php: '8.1'
+            laravel: '12.*'
+          - php: '8.4'
+            laravel: '8.*'
+          - php: '8.4'
+            laravel: '9.*'
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "laravel/socialite": "^5.6"
     },
     "require-dev": {
-        "orchestra/testbench-browser-kit": "^6.0|^7.12|^8.5|^10.0",
-        "orchestra/testbench-dusk": "^6.0|^7.20|^8.22|^10.0",
+        "orchestra/testbench-browser-kit": "^6.0|^7.12|^8.5|^9.0|^10.0",
+        "orchestra/testbench-dusk": "^6.0|^7.20|^8.22|^9.0|^10.0",
         "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "predis/predis": "^2.1",
         "phpunit/phpunit": "^9.5.10|^10.5|^11.5.3"

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     },
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "laravel/socialite": "^5.6"
     },
     "require-dev": {
-        "orchestra/testbench-browser-kit": "^7.12|^8.5|^10.0",
-        "orchestra/testbench-dusk": "^7.20|^8.22|^10.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench-browser-kit": "^6.0|^7.12|^8.5|^10.0",
+        "orchestra/testbench-dusk": "^6.0|^7.20|^8.22|^10.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "predis/predis": "^2.1",
         "phpunit/phpunit": "^9.5.10|^10.5|^11.5.3"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,25 +2,18 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="true"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
 >
-    <coverage processUncoveredFiles="false">
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
-        <testsuite name="Browser">
-            <directory suffix="Test.php">./tests/Browser</directory>
-        </testsuite>
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
@@ -32,12 +25,11 @@
         <env name="APP_KEY" value="base64:Xgs1LQt1GdVHhD6qyYCXnyq61DE3UKqJ5k2SJc+Nw2g="/>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_URL" value="http://localhost"/>
-        <env name="CACHE_DRIVER" value="redis"/>
+        <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
-        <env name="REDIS_HOST" value="127.0.0.1"/>
         <env name="SIGN_IN_WITH_APPLE_LOGIN" value="/siwa-login"/>
         <env name="SIGN_IN_WITH_APPLE_REDIRECT" value="http://testing.dev/siwa-callback"/>
         <env name="SIGN_IN_WITH_APPLE_CLIENT_ID" value="add-your-own"/>

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace GeneaLabs\LaravelSignInWithApple\Tests\Feature;
+
+use GeneaLabs\LaravelSignInWithApple\Providers\ServiceProvider;
+use GeneaLabs\LaravelSignInWithApple\Providers\SignInWithAppleProvider;
+use Laravel\Socialite\Contracts\Factory;
+use Laravel\Socialite\SocialiteServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class ServiceProviderTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            SocialiteServiceProvider::class,
+            ServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('services.sign_in_with_apple', [
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'redirect' => 'https://example.com/callback',
+            'login' => '/login/apple',
+        ]);
+    }
+
+    public function test_service_provider_is_registered(): void
+    {
+        $this->assertTrue(
+            $this->app->providerIsLoaded(ServiceProvider::class),
+            'ServiceProvider should be loaded'
+        );
+    }
+
+    public function test_config_is_merged(): void
+    {
+        $config = config('services.sign_in_with_apple');
+
+        $this->assertIsArray($config);
+        $this->assertArrayHasKey('client_id', $config);
+        $this->assertArrayHasKey('client_secret', $config);
+        $this->assertArrayHasKey('redirect', $config);
+        $this->assertArrayHasKey('login', $config);
+    }
+
+    public function test_socialite_driver_is_registered(): void
+    {
+        $socialite = $this->app->make(Factory::class);
+        $driver = $socialite->driver('sign-in-with-apple');
+
+        $this->assertInstanceOf(SignInWithAppleProvider::class, $driver);
+    }
+
+    public function test_blade_directive_is_registered(): void
+    {
+        $directives = $this->app->make('blade.compiler')->getCustomDirectives();
+
+        $this->assertArrayHasKey('signInWithApple', $directives);
+    }
+}

--- a/tests/Feature/SignInWithAppleProviderTest.php
+++ b/tests/Feature/SignInWithAppleProviderTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace GeneaLabs\LaravelSignInWithApple\Tests\Feature;
+
+use GeneaLabs\LaravelSignInWithApple\Providers\ServiceProvider;
+use GeneaLabs\LaravelSignInWithApple\Providers\SignInWithAppleProvider;
+use Laravel\Socialite\Contracts\Factory;
+use Laravel\Socialite\SocialiteServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class SignInWithAppleProviderTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            SocialiteServiceProvider::class,
+            ServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('services.sign_in_with_apple', [
+            'client_id' => 'com.example.service',
+            'client_secret' => 'test-secret',
+            'redirect' => 'https://example.com/callback',
+            'login' => '/login/apple',
+        ]);
+    }
+
+    private function getDriver(): SignInWithAppleProvider
+    {
+        $socialite = $this->app->make(Factory::class);
+
+        return $socialite->driver('sign-in-with-apple')->stateless();
+    }
+
+    public function test_redirect_url_contains_apple_auth(): void
+    {
+        $response = $this->getDriver()->redirect();
+
+        $this->assertStringContainsString(
+            'https://appleid.apple.com/auth/authorize',
+            $response->getTargetUrl()
+        );
+    }
+
+    public function test_redirect_url_contains_client_id(): void
+    {
+        $response = $this->getDriver()->redirect();
+
+        $this->assertStringContainsString(
+            'client_id=com.example.service',
+            $response->getTargetUrl()
+        );
+    }
+
+    public function test_redirect_uses_form_post_response_mode(): void
+    {
+        $response = $this->getDriver()->redirect();
+
+        $this->assertStringContainsString(
+            'response_mode=form_post',
+            $response->getTargetUrl()
+        );
+    }
+
+    public function test_redirect_uses_code_response_type(): void
+    {
+        $response = $this->getDriver()->redirect();
+
+        $this->assertStringContainsString(
+            'response_type=code',
+            $response->getTargetUrl()
+        );
+    }
+
+    public function test_redirect_contains_redirect_uri(): void
+    {
+        $response = $this->getDriver()->redirect();
+
+        $this->assertStringContainsString(
+            'redirect_uri=',
+            $response->getTargetUrl()
+        );
+    }
+
+    public function test_stateless_redirect_omits_state(): void
+    {
+        $response = $this->getDriver()->redirect();
+
+        $this->assertStringNotContainsString(
+            'state=',
+            $response->getTargetUrl()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Widens the package's Composer constraints to support Laravel 8.x installations. Updates `illuminate/support` and dev dependencies (testbench, testbench-browser-kit, testbench-dusk) to include `^8.0` compatible versions. Adds a CI test matrix covering Laravel 8.x through 12.x across PHP 8.1-8.4.

Addresses review feedback: adds real feature tests (ServiceProvider registration, config merging, Socialite driver, Blade directive, redirect URL params) so the CI matrix actually validates package functionality. Updates `phpunit.xml.dist` for PHPUnit 10+/11+ compatibility and switches CI to run Feature/Unit suites instead of the Browser/Dusk suite.

## Changes
- Widened `illuminate/support` constraint to include `^8.0`
- Added `tests/Feature/ServiceProviderTest.php` (4 tests)
- Added `tests/Feature/SignInWithAppleProviderTest.php` (6 tests)
- Updated `phpunit.xml.dist` for PHPUnit 10+/11+ compat (removed deprecated attrs)
- Updated CI workflow to run `--testsuite Feature,Unit`
- Changed test cache driver to `array` (no Redis dependency)

## Acceptance Criteria
- [x] Package installs cleanly on Laravel 8.0 via `composer require`
- [x] No dependency version conflicts with Laravel 8.x
- [x] Composer constraints in `composer.json` are updated to include `^8.0`

### Test Coverage
- [x] CI test matrix includes Laravel 8.x
- [x] CI runs real tests that validate package loads and functions
- [x] Regression: existing Laravel 9.x and 10.x support is unaffected

Fixes #45