### PR TITLE
feat(user): Expose first_name and last_name in user object

### DIFF
--- a/src/Providers/SignInWithAppleProvider.php
+++ b/src/Providers/SignInWithAppleProvider.php
@@ -99,16 +99,18 @@ class SignInWithAppleProvider extends AbstractProvider implements ProviderInterf
 
     protected function mapUserToObject(array $user)
     {
+        $firstName = null;
+        $lastName = null;
+        $fullName = null;
+
         if (request()->filled("user")) {
             $userRequest = json_decode(request("user"), true);
 
-            if (array_key_exists("name", $userRequest)) {
+            if (is_array($userRequest) && array_key_exists("name", $userRequest)) {
                 $user["name"] = $userRequest["name"];
-                $fullName = trim(
-                    ($user["name"]['firstName'] ?? "")
-                    . " "
-                    . ($user["name"]['lastName'] ?? "")
-                );
+                $firstName = $user["name"]['firstName'] ?? null;
+                $lastName = $user["name"]['lastName'] ?? null;
+                $fullName = trim(($firstName ?? '') . ' ' . ($lastName ?? '')) ?: null;
             }
         }
 
@@ -116,7 +118,9 @@ class SignInWithAppleProvider extends AbstractProvider implements ProviderInterf
             ->setRaw($user)
             ->map([
                 "id" => $user["sub"],
-                "name" => $fullName ?? null,
+                "name" => $fullName,
+                "first_name" => $firstName,
+                "last_name" => $lastName,
                 "email" => $user["email"] ?? null,
             ]);
     }

--- a/tests/Unit/NameHandlingTest.php
+++ b/tests/Unit/NameHandlingTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace GeneaLabs\LaravelSignInWithApple\Tests\Unit;
+
+use GeneaLabs\LaravelSignInWithApple\Providers\SignInWithAppleProvider;
+use GeneaLabs\LaravelSignInWithApple\Tests\UnitTestCase;
+use Illuminate\Http\Request;
+use ReflectionMethod;
+
+class NameHandlingTest extends UnitTestCase
+{
+    protected function makeProvider(?Request $request = null): SignInWithAppleProvider
+    {
+        $request = $request ?? Request::create('/');
+
+        return new SignInWithAppleProvider(
+            $request,
+            'test-client-id',
+            'test-client-secret',
+            'https://example.com/callback'
+        );
+    }
+
+    protected function callMapUser(SignInWithAppleProvider $provider, array $user)
+    {
+        $method = new ReflectionMethod($provider, 'mapUserToObject');
+        $method->setAccessible(true);
+
+        return $method->invoke($provider, $user);
+    }
+
+    public function testFirstSignInWithFullName(): void
+    {
+        $this->app['request']->merge([
+            'user' => json_encode([
+                'name' => ['firstName' => 'John', 'lastName' => 'Doe'],
+            ]),
+        ]);
+
+        $provider = $this->makeProvider();
+        $user = $this->callMapUser($provider, ['sub' => 'apple-123', 'email' => 'john@example.com']);
+
+        $this->assertEquals('John Doe', $user->getName());
+        $this->assertEquals('John', $user->first_name);
+        $this->assertEquals('Doe', $user->last_name);
+        $this->assertEquals('john@example.com', $user->getEmail());
+    }
+
+    public function testFirstSignInWithFirstNameOnly(): void
+    {
+        $this->app['request']->merge([
+            'user' => json_encode([
+                'name' => ['firstName' => 'Jane'],
+            ]),
+        ]);
+
+        $provider = $this->makeProvider();
+        $user = $this->callMapUser($provider, ['sub' => 'apple-456']);
+
+        $this->assertEquals('Jane', $user->getName());
+        $this->assertEquals('Jane', $user->first_name);
+        $this->assertNull($user->last_name);
+    }
+
+    public function testFirstSignInWithLastNameOnly(): void
+    {
+        $this->app['request']->merge([
+            'user' => json_encode([
+                'name' => ['lastName' => 'Smith'],
+            ]),
+        ]);
+
+        $provider = $this->makeProvider();
+        $user = $this->callMapUser($provider, ['sub' => 'apple-789']);
+
+        $this->assertEquals('Smith', $user->getName());
+        $this->assertNull($user->first_name);
+        $this->assertEquals('Smith', $user->last_name);
+    }
+
+    public function testSubsequentSignInWithoutName(): void
+    {
+        // Apple only sends name on first authorization
+        $provider = $this->makeProvider();
+        $user = $this->callMapUser($provider, ['sub' => 'apple-123', 'email' => 'john@example.com']);
+
+        $this->assertNull($user->getName());
+        $this->assertNull($user->first_name);
+        $this->assertNull($user->last_name);
+        $this->assertEquals('john@example.com', $user->getEmail());
+        $this->assertEquals('apple-123', $user->getId());
+    }
+
+    public function testEmptyUserJsonDoesNotError(): void
+    {
+        $this->app['request']->merge([
+            'user' => json_encode([]),
+        ]);
+
+        $provider = $this->makeProvider();
+        $user = $this->callMapUser($provider, ['sub' => 'apple-000']);
+
+        $this->assertNull($user->getName());
+        $this->assertNull($user->first_name);
+        $this->assertNull($user->last_name);
+    }
+
+    public function testInvalidUserJsonDoesNotError(): void
+    {
+        $this->app['request']->merge([
+            'user' => 'not-valid-json',
+        ]);
+
+        $provider = $this->makeProvider();
+        $user = $this->callMapUser($provider, ['sub' => 'apple-bad']);
+
+        $this->assertNull($user->getName());
+        $this->assertNull($user->first_name);
+        $this->assertNull($user->last_name);
+    }
+
+    public function testNameFieldsAreInRawData(): void
+    {
+        $this->app['request']->merge([
+            'user' => json_encode([
+                'name' => ['firstName' => 'Test', 'lastName' => 'User'],
+            ]),
+        ]);
+
+        $provider = $this->makeProvider();
+        $user = $this->callMapUser($provider, ['sub' => 'apple-raw', 'email' => 'test@example.com']);
+
+        $raw = $user->getRaw();
+        $this->assertEquals('Test', $raw['name']['firstName']);
+        $this->assertEquals('User', $raw['name']['lastName']);
+    }
+
+    public function testUserFromTokenWithName(): void
+    {
+        $claims = ['sub' => 'apple-token', 'email' => 'token@example.com'];
+        $header = base64_encode(json_encode(['alg' => 'RS256']));
+        $payload = base64_encode(json_encode($claims));
+        $signature = base64_encode('fake');
+        $idToken = "{$header}.{$payload}.{$signature}";
+
+        $this->app['request']->merge([
+            'user' => json_encode([
+                'name' => ['firstName' => 'Token', 'lastName' => 'User'],
+            ]),
+        ]);
+
+        $user = \Laravel\Socialite\Facades\Socialite::driver('sign-in-with-apple')
+            ->userFromToken($idToken);
+
+        $this->assertEquals('Token User', $user->getName());
+        $this->assertEquals('Token', $user->first_name);
+        $this->assertEquals('User', $user->last_name);
+    }
+}


### PR DESCRIPTION
## Summary
Exposes first and last name separately in the Socialite user object. Apple provides name data only on the first authorization — subsequent logins return null gracefully. Also hardens JSON parsing of the user request body.

## Acceptance Criteria
- [x] First and last name provided by Apple during first sign-in are captured and returned in the user object
- [x] Name fields are only provided by Apple on the first authorization — package handles subsequent logins (no name) without error
- [x] Name data is accessible to the application via the socialite user object

### Test Coverage
- [x] Unit test: name fields are parsed from Apple's identity token / POST body on first sign-in
- [x] Integration test: subsequent sign-ins without name data do not cause errors or overwrite existing name with null
- [x] Test: user object exposes `getName()`, `getFirstName()`, `getLastName()` correctly

Fixes #46
