### PR TITLE
fix(auth): Handle invalid_client error with descriptive exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ config(['services.sign_in_with_apple.client_secret' => $secret]);
 
 Required env vars for `fromConfig()`:
 ```env
-APPLE_TEAM_ID=your-team-id
-APPLE_KEY_ID=your-key-id
-APPLE_PRIVATE_KEY_PATH=/path/to/key.p8
+SIGN_IN_WITH_APPLE_TEAM_ID=your-team-id
+SIGN_IN_WITH_APPLE_KEY_ID=your-key-id
+SIGN_IN_WITH_APPLE_PRIVATE_KEY_PATH=/path/to/key.p8
 ```
 
 5. Set the necessary environment variables in your `.env` file:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,42 @@ We thank the following sponsors for their generosity, please take a moment to ch
         ruby client_secret.rb
         ```
 
+
+#### Alternative: Generate client_secret in PHP
+
+Instead of using the Ruby script above, you can generate the client secret JWT directly in PHP using this package's built-in helper:
+
+```php
+use GeneaLabs\LaravelSignInWithApple\Support\ClientSecretGenerator;
+
+// One-off generation
+$secret = ClientSecretGenerator::generate(
+    teamId: 'YOUR_TEAM_ID',
+    clientId: 'com.example.service',
+    keyId: 'YOUR_KEY_ID',
+    privateKey: file_get_contents(storage_path('keys/apple-auth-key.p8')),
+    ttlDays: 180, // Max 180 days
+);
+
+// Or use config/env values automatically
+$secret = ClientSecretGenerator::fromConfig();
+```
+
+You can use an Artisan command or scheduled task to auto-rotate the secret before it expires:
+
+```php
+// In a scheduled command or service provider
+$secret = ClientSecretGenerator::fromConfig(ttlDays: 180);
+config(['services.sign_in_with_apple.client_secret' => $secret]);
+```
+
+Required env vars for `fromConfig()`:
+```env
+APPLE_TEAM_ID=your-team-id
+APPLE_KEY_ID=your-key-id
+APPLE_PRIVATE_KEY_PATH=/path/to/key.p8
+```
+
 5. Set the necessary environment variables in your `.env` file:
 
     ```env

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "firebase/php-jwt": "^6.0",
         "laravel/socialite": "^5.6"
     },
     "require-dev": {

--- a/config/services.php
+++ b/config/services.php
@@ -4,6 +4,10 @@ return [
     "sign_in_with_apple" => [
         "client_id" => env("SIGN_IN_WITH_APPLE_CLIENT_ID"),
         "client_secret" => env("SIGN_IN_WITH_APPLE_CLIENT_SECRET"),
+        "team_id" => env("SIGN_IN_WITH_APPLE_TEAM_ID"),
+        "key_id" => env("SIGN_IN_WITH_APPLE_KEY_ID"),
+        "private_key_path" => env("SIGN_IN_WITH_APPLE_PRIVATE_KEY_PATH"),
+        "private_key" => env("SIGN_IN_WITH_APPLE_PRIVATE_KEY"),
         "redirect" => env("SIGN_IN_WITH_APPLE_REDIRECT"),
         // Auto-register package routes
         "routes" => [

--- a/src/Support/ClientSecretGenerator.php
+++ b/src/Support/ClientSecretGenerator.php
@@ -23,19 +23,6 @@ use InvalidArgumentException;
  */
 class ClientSecretGenerator
 {
-    /**
-     * Generate an Apple client_secret JWT.
-     *
-     * @param string $teamId    Your Apple Developer Team ID
-     * @param string $clientId  Your Services ID (e.g. com.example.service)
-     * @param string $keyId     The Key ID from your Apple private key
-     * @param string $privateKey The contents of your .p8 private key file
-     * @param int    $ttlDays   Token validity in days (max 180)
-     *
-     * @return string The signed JWT client secret
-     *
-     * @throws InvalidArgumentException If required parameters are empty or ttlDays exceeds 180
-     */
     public static function generate(
         string $teamId,
         string $clientId,
@@ -58,17 +45,6 @@ class ClientSecretGenerator
         return JWT::encode($payload, $privateKey, 'ES256', $keyId);
     }
 
-    /**
-     * Generate a client secret using values from the Laravel config.
-     *
-     * All values are read via config() to ensure compatibility with
-     * config caching (php artisan config:cache). Set the corresponding
-     * SIGN_IN_WITH_APPLE_* env vars in your .env file.
-     *
-     * @param int $ttlDays Token validity in days (max 180)
-     *
-     * @return string The signed JWT client secret
-     */
     public static function fromConfig(int $ttlDays = 180): string
     {
         $teamId = config('services.sign_in_with_apple.team_id', '');
@@ -78,7 +54,14 @@ class ClientSecretGenerator
         $privateKeyPath = config('services.sign_in_with_apple.private_key_path', '');
         $privateKey = config('services.sign_in_with_apple.private_key', '');
 
-        if ($privateKeyPath && file_exists($privateKeyPath)) {
+        if ($privateKeyPath) {
+            if (! file_exists($privateKeyPath)) {
+                throw new InvalidArgumentException(
+                    "Apple private key file not found at: {$privateKeyPath}. "
+                    . 'Check your SIGN_IN_WITH_APPLE_PRIVATE_KEY_PATH env var.'
+                );
+            }
+
             $privateKey = file_get_contents($privateKeyPath);
         }
 
@@ -108,7 +91,10 @@ class ClientSecretGenerator
             throw new InvalidArgumentException('Apple private key is required. Provide the .p8 file contents.');
         }
 
-        if ($ttlDays < 1 || $ttlDays > 180) {
+        if (
+            $ttlDays < 1
+            || $ttlDays > 180
+        ) {
             throw new InvalidArgumentException('TTL must be between 1 and 180 days. Apple rejects longer-lived secrets.');
         }
     }

--- a/src/Support/ClientSecretGenerator.php
+++ b/src/Support/ClientSecretGenerator.php
@@ -59,11 +59,11 @@ class ClientSecretGenerator
     }
 
     /**
-     * Generate a client secret using values from the Laravel config/env.
+     * Generate a client secret using values from the Laravel config.
      *
-     * Expected env vars:
-     *   APPLE_TEAM_ID, APPLE_CLIENT_ID (or SIGN_IN_WITH_APPLE_CLIENT_ID),
-     *   APPLE_KEY_ID, APPLE_PRIVATE_KEY_PATH (or APPLE_PRIVATE_KEY)
+     * All values are read via config() to ensure compatibility with
+     * config caching (php artisan config:cache). Set the corresponding
+     * SIGN_IN_WITH_APPLE_* env vars in your .env file.
      *
      * @param int $ttlDays Token validity in days (max 180)
      *
@@ -71,12 +71,12 @@ class ClientSecretGenerator
      */
     public static function fromConfig(int $ttlDays = 180): string
     {
-        $teamId = config('services.sign_in_with_apple.team_id', env('APPLE_TEAM_ID', ''));
-        $clientId = config('services.sign_in_with_apple.client_id', env('APPLE_CLIENT_ID', ''));
-        $keyId = config('services.sign_in_with_apple.key_id', env('APPLE_KEY_ID', ''));
+        $teamId = config('services.sign_in_with_apple.team_id', '');
+        $clientId = config('services.sign_in_with_apple.client_id', '');
+        $keyId = config('services.sign_in_with_apple.key_id', '');
 
-        $privateKeyPath = env('APPLE_PRIVATE_KEY_PATH', '');
-        $privateKey = env('APPLE_PRIVATE_KEY', '');
+        $privateKeyPath = config('services.sign_in_with_apple.private_key_path', '');
+        $privateKey = config('services.sign_in_with_apple.private_key', '');
 
         if ($privateKeyPath && file_exists($privateKeyPath)) {
             $privateKey = file_get_contents($privateKeyPath);

--- a/src/Support/ClientSecretGenerator.php
+++ b/src/Support/ClientSecretGenerator.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace GeneaLabs\LaravelSignInWithApple\Support;
+
+use Firebase\JWT\JWT;
+use InvalidArgumentException;
+
+/**
+ * Generate Apple Sign In client secret JWTs in PHP.
+ *
+ * Apple requires a signed JWT as the client_secret when exchanging authorization
+ * codes for tokens. This utility generates that JWT using your private key,
+ * eliminating the need for the Ruby script in the README.
+ *
+ * Usage:
+ *     $secret = ClientSecretGenerator::generate(
+ *         teamId: 'YOUR_TEAM_ID',
+ *         clientId: 'com.example.service',
+ *         keyId: 'YOUR_KEY_ID',
+ *         privateKey: file_get_contents('/path/to/key.p8'),
+ *         ttlDays: 180,
+ *     );
+ */
+class ClientSecretGenerator
+{
+    /**
+     * Generate an Apple client_secret JWT.
+     *
+     * @param string $teamId    Your Apple Developer Team ID
+     * @param string $clientId  Your Services ID (e.g. com.example.service)
+     * @param string $keyId     The Key ID from your Apple private key
+     * @param string $privateKey The contents of your .p8 private key file
+     * @param int    $ttlDays   Token validity in days (max 180)
+     *
+     * @return string The signed JWT client secret
+     *
+     * @throws InvalidArgumentException If required parameters are empty or ttlDays exceeds 180
+     */
+    public static function generate(
+        string $teamId,
+        string $clientId,
+        string $keyId,
+        string $privateKey,
+        int $ttlDays = 180,
+    ): string {
+        static::validate($teamId, $clientId, $keyId, $privateKey, $ttlDays);
+
+        $now = time();
+
+        $payload = [
+            'iss' => $teamId,
+            'iat' => $now,
+            'exp' => $now + ($ttlDays * 86400),
+            'aud' => 'https://appleid.apple.com',
+            'sub' => $clientId,
+        ];
+
+        return JWT::encode($payload, $privateKey, 'ES256', $keyId);
+    }
+
+    /**
+     * Generate a client secret using values from the Laravel config/env.
+     *
+     * Expected env vars:
+     *   APPLE_TEAM_ID, APPLE_CLIENT_ID (or SIGN_IN_WITH_APPLE_CLIENT_ID),
+     *   APPLE_KEY_ID, APPLE_PRIVATE_KEY_PATH (or APPLE_PRIVATE_KEY)
+     *
+     * @param int $ttlDays Token validity in days (max 180)
+     *
+     * @return string The signed JWT client secret
+     */
+    public static function fromConfig(int $ttlDays = 180): string
+    {
+        $teamId = config('services.sign_in_with_apple.team_id', env('APPLE_TEAM_ID', ''));
+        $clientId = config('services.sign_in_with_apple.client_id', env('APPLE_CLIENT_ID', ''));
+        $keyId = config('services.sign_in_with_apple.key_id', env('APPLE_KEY_ID', ''));
+
+        $privateKeyPath = env('APPLE_PRIVATE_KEY_PATH', '');
+        $privateKey = env('APPLE_PRIVATE_KEY', '');
+
+        if ($privateKeyPath && file_exists($privateKeyPath)) {
+            $privateKey = file_get_contents($privateKeyPath);
+        }
+
+        return static::generate($teamId, $clientId, $keyId, $privateKey, $ttlDays);
+    }
+
+    protected static function validate(
+        string $teamId,
+        string $clientId,
+        string $keyId,
+        string $privateKey,
+        int $ttlDays,
+    ): void {
+        if (empty($teamId)) {
+            throw new InvalidArgumentException('Apple team_id is required.');
+        }
+
+        if (empty($clientId)) {
+            throw new InvalidArgumentException('Apple client_id (Services ID) is required.');
+        }
+
+        if (empty($keyId)) {
+            throw new InvalidArgumentException('Apple key_id is required.');
+        }
+
+        if (empty($privateKey)) {
+            throw new InvalidArgumentException('Apple private key is required. Provide the .p8 file contents.');
+        }
+
+        if ($ttlDays < 1 || $ttlDays > 180) {
+            throw new InvalidArgumentException('TTL must be between 1 and 180 days. Apple rejects longer-lived secrets.');
+        }
+    }
+}

--- a/tests/Unit/ClientSecretGeneratorTest.php
+++ b/tests/Unit/ClientSecretGeneratorTest.php
@@ -14,8 +14,8 @@ class ClientSecretGeneratorTest extends UnitTestCase
     protected function generateTestKey(): string
     {
         $key = openssl_pkey_new([
-            'curve_name' => 'prime256v1',
             'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'ec' => ['curve_name' => 'prime256v1'],
         ]);
 
         openssl_pkey_export($key, $pem);
@@ -150,5 +150,67 @@ class ClientSecretGeneratorTest extends UnitTestCase
             privateKey: 'fake-key',
             ttlDays: 0,
         );
+    }
+
+    public function testFromConfigReadsConfigValues(): void
+    {
+        $privateKey = $this->generateTestKey();
+
+        config([
+            'services.sign_in_with_apple.team_id' => 'CONFIG_TEAM',
+            'services.sign_in_with_apple.client_id' => 'com.config.service',
+            'services.sign_in_with_apple.key_id' => 'CONFIG_KEY',
+            'services.sign_in_with_apple.private_key' => $privateKey,
+            'services.sign_in_with_apple.private_key_path' => '',
+        ]);
+
+        $jwt = ClientSecretGenerator::fromConfig(ttlDays: 30);
+
+        $parts = explode('.', $jwt);
+        $payload = json_decode(base64_decode($parts[1]), true);
+
+        $this->assertEquals('CONFIG_TEAM', $payload['iss']);
+        $this->assertEquals('com.config.service', $payload['sub']);
+    }
+
+    public function testFromConfigPrefersKeyPathOverKeyContent(): void
+    {
+        $privateKey = $this->generateTestKey();
+        $tempFile = tempnam(sys_get_temp_dir(), 'apple_key_');
+        file_put_contents($tempFile, $privateKey);
+
+        config([
+            'services.sign_in_with_apple.team_id' => 'TEAM_PATH',
+            'services.sign_in_with_apple.client_id' => 'com.path.service',
+            'services.sign_in_with_apple.key_id' => 'KEY_PATH',
+            'services.sign_in_with_apple.private_key' => 'this-would-fail-if-used',
+            'services.sign_in_with_apple.private_key_path' => $tempFile,
+        ]);
+
+        $jwt = ClientSecretGenerator::fromConfig();
+
+        $parts = explode('.', $jwt);
+        $this->assertCount(3, $parts);
+
+        $payload = json_decode(base64_decode($parts[1]), true);
+        $this->assertEquals('TEAM_PATH', $payload['iss']);
+
+        unlink($tempFile);
+    }
+
+    public function testFromConfigThrowsWhenKeyPathSetButFileMissing(): void
+    {
+        config([
+            'services.sign_in_with_apple.team_id' => 'TEAM123',
+            'services.sign_in_with_apple.client_id' => 'com.example.service',
+            'services.sign_in_with_apple.key_id' => 'KEY456',
+            'services.sign_in_with_apple.private_key' => 'fallback-key',
+            'services.sign_in_with_apple.private_key_path' => '/nonexistent/path/key.p8',
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not found');
+
+        ClientSecretGenerator::fromConfig();
     }
 }

--- a/tests/Unit/ClientSecretGeneratorTest.php
+++ b/tests/Unit/ClientSecretGeneratorTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace GeneaLabs\LaravelSignInWithApple\Tests\Unit;
+
+use GeneaLabs\LaravelSignInWithApple\Support\ClientSecretGenerator;
+use GeneaLabs\LaravelSignInWithApple\Tests\UnitTestCase;
+use InvalidArgumentException;
+
+class ClientSecretGeneratorTest extends UnitTestCase
+{
+    /**
+     * Generate a test EC P-256 private key.
+     */
+    protected function generateTestKey(): string
+    {
+        $key = openssl_pkey_new([
+            'curve_name' => 'prime256v1',
+            'private_key_type' => OPENSSL_KEYTYPE_EC,
+        ]);
+
+        openssl_pkey_export($key, $pem);
+
+        return $pem;
+    }
+
+    public function testGeneratesValidJwt(): void
+    {
+        $privateKey = $this->generateTestKey();
+
+        $jwt = ClientSecretGenerator::generate(
+            teamId: 'TEAM123',
+            clientId: 'com.example.service',
+            keyId: 'KEY456',
+            privateKey: $privateKey,
+            ttlDays: 180,
+        );
+
+        $this->assertNotEmpty($jwt);
+
+        // JWT should have 3 parts
+        $parts = explode('.', $jwt);
+        $this->assertCount(3, $parts);
+
+        // Decode header
+        $header = json_decode(base64_decode($parts[0]), true);
+        $this->assertEquals('ES256', $header['alg']);
+        $this->assertEquals('KEY456', $header['kid']);
+
+        // Decode payload
+        $payload = json_decode(base64_decode($parts[1]), true);
+        $this->assertEquals('TEAM123', $payload['iss']);
+        $this->assertEquals('com.example.service', $payload['sub']);
+        $this->assertEquals('https://appleid.apple.com', $payload['aud']);
+        $this->assertArrayHasKey('iat', $payload);
+        $this->assertArrayHasKey('exp', $payload);
+        $this->assertEquals($payload['iat'] + (180 * 86400), $payload['exp']);
+    }
+
+    public function testCustomTtl(): void
+    {
+        $privateKey = $this->generateTestKey();
+
+        $jwt = ClientSecretGenerator::generate(
+            teamId: 'TEAM123',
+            clientId: 'com.example.service',
+            keyId: 'KEY456',
+            privateKey: $privateKey,
+            ttlDays: 30,
+        );
+
+        $parts = explode('.', $jwt);
+        $payload = json_decode(base64_decode($parts[1]), true);
+        $this->assertEquals($payload['iat'] + (30 * 86400), $payload['exp']);
+    }
+
+    public function testThrowsOnEmptyTeamId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('team_id');
+
+        ClientSecretGenerator::generate(
+            teamId: '',
+            clientId: 'com.example.service',
+            keyId: 'KEY456',
+            privateKey: 'fake-key',
+        );
+    }
+
+    public function testThrowsOnEmptyClientId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('client_id');
+
+        ClientSecretGenerator::generate(
+            teamId: 'TEAM123',
+            clientId: '',
+            keyId: 'KEY456',
+            privateKey: 'fake-key',
+        );
+    }
+
+    public function testThrowsOnEmptyKeyId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('key_id');
+
+        ClientSecretGenerator::generate(
+            teamId: 'TEAM123',
+            clientId: 'com.example.service',
+            keyId: '',
+            privateKey: 'fake-key',
+        );
+    }
+
+    public function testThrowsOnEmptyPrivateKey(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('private key');
+
+        ClientSecretGenerator::generate(
+            teamId: 'TEAM123',
+            clientId: 'com.example.service',
+            keyId: 'KEY456',
+            privateKey: '',
+        );
+    }
+
+    public function testThrowsOnTtlExceeding180Days(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('180 days');
+
+        ClientSecretGenerator::generate(
+            teamId: 'TEAM123',
+            clientId: 'com.example.service',
+            keyId: 'KEY456',
+            privateKey: 'fake-key',
+            ttlDays: 181,
+        );
+    }
+
+    public function testThrowsOnTtlLessThanOneDay(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        ClientSecretGenerator::generate(
+            teamId: 'TEAM123',
+            clientId: 'com.example.service',
+            keyId: 'KEY456',
+            privateKey: 'fake-key',
+            ttlDays: 0,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Catches `invalid_client` errors from Apple's token endpoint with descriptive `InvalidAppleCredentialsException`, validates config on driver resolution, and provides a PHP `ClientSecretGenerator` utility to correctly generate client secrets.

## Changes
- Catch `invalid_client` and `invalid_grant` errors with descriptive exceptions in both `getAccessTokenResponse()` and `getAccessToken()` code paths
- Validate Apple config at driver resolution time with clear guidance
- Add `ClientSecretGenerator` for PHP-based JWT client secret generation
- Custom `InvalidAppleCredentialsException` with context array
- README troubleshooting and PHP generator docs

### Review Feedback Addressed
- Added `firebase/php-jwt` to `require` in `composer.json`
- Wrapped `getAccessToken()` with the same `ClientException` error handling as `getAccessTokenResponse()`
- Replaced direct `env()` calls in `ClientSecretGenerator::fromConfig()` with `config()` for config caching compatibility
- Unified env var naming to `SIGN_IN_WITH_APPLE_*` convention (added `team_id`, `key_id`, `private_key_path`, `private_key` to config/services.php)

## Acceptance Criteria
- [x] `invalid_client` error from Apple's token endpoint is caught and a user-friendly message is returned
- [x] Root cause is documented: likely misconfigured `client_secret` or expired key
- [x] Package includes validation/helper for `client_secret` generation to prevent this error

### Test Coverage
- [x] Unit test: `invalid_client` response from Apple is handled gracefully (no unhandled exception)
- [x] Integration test: descriptive error is surfaced to the application when Apple returns 400

Fixes #53
